### PR TITLE
Fix update script appending ',' character to table names

### DIFF
--- a/setup/tools/clisetup/update.func.php
+++ b/setup/tools/clisetup/update.func.php
@@ -63,8 +63,8 @@ function update()
 
     sleep(1);
 
-    $sql   = trim($sql)   ? array_unique(explode(' ', trim($sql)))   : [];
-    $build = trim($build) ? array_unique(explode(' ', trim($build))) : [];
+    $sql   = trim($sql)   ? array_unique(explode(', ', trim($sql)))   : [];
+    $build = trim($build) ? array_unique(explode(', ', trim($build))) : [];
 
     if ($sql)
         CLI::write('The following table(s) require syncing: '.implode(', ', $sql));


### PR DESCRIPTION
The current code splits table names by ' '  leaving the ',' character in the table names

Error without this PR:
![image](https://user-images.githubusercontent.com/1153754/87876619-8e420900-c9d9-11ea-989e-121daa52ac42.png)

With this PR:
![image](https://user-images.githubusercontent.com/1153754/87876624-9ef27f00-c9d9-11ea-9c2e-3d80fdaf5228.png)

aowow_dbversion table content:
![image](https://user-images.githubusercontent.com/1153754/87876629-af0a5e80-c9d9-11ea-9031-af3863a0ee38.png)
