### PR TITLE
Fix excepton in smartAI

### DIFF
--- a/includes/smartAI.class.php
+++ b/includes/smartAI.class.php
@@ -292,7 +292,7 @@ class SmartAI
 
         if ($smartTALs)
         {
-            if ($TALActList = DB::World()->selectCol('SELECT action_type, action_param1, action_param2, action_param3, action_param4, action_param5, action_param6 FROM smart_scripts WHERE source_type = ?d AND action_type IN (?a) AND entryOrGUID IN (?a)', SAI_SRC_TYPE_ACTIONLIST, $lookup, $smartTALs))
+            if ($TALActList = DB::World()->select('SELECT action_type, action_param1, action_param2, action_param3, action_param4, action_param5, action_param6 FROM smart_scripts WHERE source_type = ?d AND action_type IN (?a) AND entryOrGUID IN (?a)', SAI_SRC_TYPE_ACTIONLIST, array_merge(...array_values($lookup)), $smartTALs))
             {
                 foreach ($TALActList as $e)
                 {


### PR DESCRIPTION
Fix "Cannot access offset of type string on string" in smartAI.class.php when loading /?npc=68 , caused by using `selectCol` instead of `select` and trying to access the result (which is only the value of the first column) as a row